### PR TITLE
Support multiple StyleTags and GotoOptions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+require:
+ - standard
+
+inherit_gem:
+  standard: config/ruby-3.0.yml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    browserless (1.0.1)
+    browserless (1.0.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/browserless/client.rb
+++ b/lib/browserless/client.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
 require_relative "options"
+require_relative "goto_options"
 require_relative "style_tag"
 
 module Browserless
   class ApikeyError < StandardError; end
 
   class Client
-    attr_reader :html, :url, :style_tag, :emulate_media, :options
+    attr_reader :html, :url, :style_tag, :emulate_media, :options, :goto_options
 
-    def initialize(html:, options: {}, **kwargs)
+    def initialize(html:, options: {}, goto_options: {}, **kwargs)
       @html = html
       @options = Options.new(**options).to_h
-      @style_tag = StyleTag.new(kwargs[:style_tag]).to_h
+      @goto_options = GotoOptions.new(**goto_options).to_h
+      @style_tag = StyleTags.new(kwargs[:style_tag]).to_a
       @emulate_media = config_value(:emulate_media, kwargs[:emulate_media]) || "screen"
       @url = Browserless.configuration.url
     end
@@ -60,8 +62,9 @@ module Browserless
         html: html,
         safeMode: safe_mode,
         emulateMedia: emulate_media,
-        addStyleTag: [style_tag],
-        options: options
+        addStyleTag: style_tag,
+        options: options,
+        gotoOptions: goto_options
       }
     end
 

--- a/lib/browserless/configuration.rb
+++ b/lib/browserless/configuration.rb
@@ -5,7 +5,7 @@ module Browserless
 
   class Configuration
     attr_writer :api_key
-    attr_accessor :options, :emulate_media, :style_tag
+    attr_accessor :options, :goto_options, :emulate_media, :style_tag
 
     BASE_URL = "https://chrome.browserless.io/pdf?token="
 

--- a/lib/browserless/goto_options.rb
+++ b/lib/browserless/goto_options.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Browserless
+  class GotoOptions
+    attr_reader :options, :timeout, :wait_until
+
+    def initialize(**options)
+      @options = options
+      @timeout = config_value(:timeout) || 0
+      @wait_until = config_value(:wait_until) || "load"
+    end
+
+    def to_h
+      {
+        timeout: timeout,
+        waitUntil: wait_until
+      }
+    end
+
+    private
+
+    def config_value(key)
+      return options[key] if Browserless.configuration.goto_options.nil?
+
+      options[key] || Browserless.configuration.goto_options[key]
+    end
+  end
+end

--- a/lib/browserless/options.rb
+++ b/lib/browserless/options.rb
@@ -5,7 +5,7 @@ module Browserless
     HEADER_TEMPLATE = "<div></div>" # empty header
     FOOTER_TEMPLATE = "<div style='font-size: 11px; margin-left: 40px; font: Helvetica'><span class='pageNumber'></span> of <span class='totalPages'></span></div>"
 
-    attr_reader :display_header_footer, :margin, :pdf_format, :print_background, :header_template, :footer_template, :options, :landscape
+    attr_reader :display_header_footer, :margin, :pdf_format, :print_background, :header_template, :footer_template, :options, :landscape, :timeout
 
     def initialize(**options)
       @options = options
@@ -16,6 +16,7 @@ module Browserless
       @header_template = config_value(:header_template) || HEADER_TEMPLATE
       @footer_template = config_value(:footer_template) || FOOTER_TEMPLATE
       @display_header_footer = config_value(:display_header_footer) || false
+      @timeout = config_value(:timeout) || 0
     end
 
     def to_h
@@ -26,7 +27,8 @@ module Browserless
         margin: margin,
         format: pdf_format,
         headerTemplate: header_template,
-        footerTemplate: footer_template
+        footerTemplate: footer_template,
+        timeout: timeout
       }
     end
 

--- a/lib/browserless/style_tag.rb
+++ b/lib/browserless/style_tag.rb
@@ -1,6 +1,23 @@
 # frozen_string_literal: true
 
 module Browserless
+  class StyleTags
+    attr_reader :style_tags
+
+    def initialize(style_tags = [])
+      @style_tags = Array(style_tags)
+    end
+
+    def to_a
+      style_tags.filter_map do |style_tag|
+        tag = StyleTag.new(style_tag).to_h
+        next if tag.key?(:content) && tag[:content].nil?
+
+        tag
+      end
+    end
+  end
+
   class StyleTag
     attr_reader :style_tag
 

--- a/lib/browserless/style_tags.rb
+++ b/lib/browserless/style_tags.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class StyleTagsTest < Minitest::Test
+  def setup
+    Browserless.configure do |config|
+      config.api_key = "test_key"
+    end
+  end
+
+  def teardown
+    Browserless.configure { nil }
+  end
+
+  def test_to_a_with_url
+    style_tag = Browserless::StyleTags.new("http://example.com/styles.css")
+    assert_equal([{url: "http://example.com/styles.css"}], style_tag.to_a)
+  end
+
+  def test_to_a_with_content
+    style_tag = Browserless::StyleTags.new("body { font-family: Arial; }")
+    assert_equal([{content: "body { font-family: Arial; }"}], style_tag.to_a)
+  end
+
+  def test_to_a_with_url_and_content
+    style_tag = Browserless::StyleTags.new(["http://example.com/styles.css", "body { font-family: Arial; }"])
+
+    assert_equal([
+      {url: "http://example.com/styles.css"},
+      {content: "body { font-family: Arial; }"}
+    ], style_tag.to_a)
+  end
+end

--- a/test/models/client_test.rb
+++ b/test/models/client_test.rb
@@ -24,7 +24,7 @@ class Browserless::ClientTest < Minitest::Test
 
     assert_equal "<html></html>", client.html
     assert_equal "screen", client.emulate_media
-    assert_equal({content: nil}, client.style_tag)
+    assert_equal([], client.style_tag)
     assert_equal Browserless.configuration.url, client.url
   end
 
@@ -39,7 +39,7 @@ class Browserless::ClientTest < Minitest::Test
   def test_initialize_with_style_tag
     client = Browserless::Client.new(html: "<html></html>", style_tag: "body { font-family: Arial; }")
 
-    assert_equal({content: "body { font-family: Arial; }"}, client.style_tag)
+    assert_equal([{content: "body { font-family: Arial; }"}], client.style_tag)
   end
 
   def test_initialize_with_custom_options
@@ -63,7 +63,8 @@ class Browserless::ClientTest < Minitest::Test
       margin: {},
       format: "A4",
       headerTemplate: "<div></div>",
-      footerTemplate: "<div style='font-size: 11px; margin-left: 40px; font: Helvetica'><span class='pageNumber'></span> of <span class='totalPages'></span></div>"
+      footerTemplate: "<div style='font-size: 11px; margin-left: 40px; font: Helvetica'><span class='pageNumber'></span> of <span class='totalPages'></span></div>",
+      timeout: 0
     }, client.options)
   end
 end

--- a/test/models/goto_options_test.rb
+++ b/test/models/goto_options_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+class GotoOptionsTest < Minitest::Test
+  def setup
+    Browserless.configure do |config|
+      config.api_key = "test_key"
+    end
+  end
+
+  def teardown
+    Browserless.configure { nil }
+  end
+
+  def test_initialize_with_default_values
+    Browserless.configure do |config|
+      config.api_key = "test_key"
+      config.goto_options = {}
+    end
+
+    options = Browserless::GotoOptions.new
+
+    assert_equal 0, options.timeout
+    assert_equal "load", options.wait_until
+  end
+
+  def test_initialize_with_custom_values
+    options = Browserless::GotoOptions.new(timeout: 1000, wait_until: "networkidle0")
+
+    assert_equal 1000, options.timeout
+    assert_equal "networkidle0", options.wait_until
+  end
+
+  def test_initialize_with_custom_values_in_initializer
+    Browserless.configure do |config|
+      config.api_key = "test_key"
+      config.goto_options = {
+        timeout: 15_000,
+        wait_until: "networkidle2"
+      }
+    end
+
+    options = Browserless::GotoOptions.new
+
+    assert_equal 15_000, options.timeout
+    assert_equal "networkidle2", options.wait_until
+  end
+
+  def test_initialize_with_custom_values_in_initializer_and_overwrite
+    Browserless.configure do |config|
+      config.api_key = "test_key"
+      config.goto_options = {
+        timeout: 1000
+      }
+    end
+
+    options = Browserless::Options.new(timeout: 10_000)
+
+    assert_equal 10_000, options.timeout
+  end
+end


### PR DESCRIPTION
### Styletags
This will add the ability to add more than one source for the styletag and of different kinds, it makes it possible to have links to public CSS and the ability to load your local CSS. This is especially useful for local development and testing.
It also fixes a bug when there is no styletag supplied, Browserless will return an error that the content can't be empty.

### GotoOptions
Adds support for additional [goto options](https://pptr.dev/api/puppeteer.page.goto#remarks) 